### PR TITLE
Display application name on sharing menu

### DIFF
--- a/src/writeShareExtensionFiles.ts
+++ b/src/writeShareExtensionFiles.ts
@@ -71,8 +71,8 @@ export function getShareExtensionInfoFilePath(platformProjectRoot: string) {
 export function getShareExtensionInfoContent() {
   return plist.build({
     CFBundleName: "$(PRODUCT_NAME)",
-    CFBundleDisplayName: "Share Extension",
-    CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)", //
+    CFBundleDisplayName: "$(PRODUCT_NAME) Share Extension",
+    CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)",
     CFBundleDevelopmentRegion: "$(DEVELOPMENT_LANGUAGE)",
     CFBundleExecutable: "$(EXECUTABLE_NAME)",
     CFBundleInfoDictionaryVersion: "6.0",


### PR DESCRIPTION
When sharing an Url from an other app, the sharing menu display "Share Extension" under the application icon (ios 12.4).

We should display the original Application Name.